### PR TITLE
fix: align data dump and dataset IRI requirements with dataset register

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -64,7 +64,7 @@ NDE requires linked data to be published both as level 1 and 2.
 
 To publish web compliant linked data (level 1) URIs (see: [[#persistent-uri]]) must resolve to the individual linked data resources contained in your data. To handle requests the [HTTP content negotation](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3) protocol must be supported. Content negotiation offers users the choice to consume the data in the serialisation of their choice, e.g. as HTML, RDF, or other formats you support.
 
-To publish linked data as a data dump (level 2) you should use [[rdf-primer|RDF]]. We recommend the use of the N-Triples serialisation for flexibility but any other RDF serialisation is valid (N-Triples, Turtle, JSON-LD, RDF/XML). You must serve the data dump through a URI with a persistent identifier. 
+To publish linked data as a data dump (level 2) you should use [[rdf-primer|RDF]]. We recommend the use of the N-Triples serialisation for flexibility but any other RDF serialisation is valid (N-Triples, Turtle, JSON-LD, RDF/XML). You must serve the data dump from a reachable HTTPS URL.
 
 We strongly recommend that vendors also implement level 3 in their products. This allows users to also query linked data collections. For compliance with level 3 you must use a [[SPARQL11-OVERVIEW|SPARQL]] endpoint.
 
@@ -100,7 +100,7 @@ If a heritage institution is considered an authority in a domain, vendors should
 
 To increase the findability of datasets of heritage institutions, you must publish the metadata of any dataset you serve. The metadata contains the description of the dataset and must be modelled in [schema.org](https://schema.org). We created a data model for the description of datasets and adopted the class https://schema.org/Dataset. You must comply with the model as documented in the [[!NDE-DATASETS|NDE Requirements for Datasets]] and specifically the [section Dataset information](https://docs.nde.nl/requirements-datasets/#dataset-information).
 
-You should serve the metadata through a URI with a persistent identifier (see section [[#persistent-uri]]). 
+The dataset itself must be identified by a persistent HTTPS IRI (see section [[#persistent-uri]]); this IRI is the dataset's permanent identifier in the register.
 
 We have created the [NDE dataset register](https://datasetregister.netwerkdigitaalerfgoed.nl/?lang=en) to help users in the cultural heritage sector find relevant datasets to link with. You must use this to register the metadata of datasets you serve. 
 


### PR DESCRIPTION
Aligns the spec with what the [dataset register’s SHACL](https://github.com/netwerk-digitaal-erfgoed/dataset-register/blob/main/requirements/shacl.ttl) actually enforces.

- **Level-2 data dumps**: previously required "a URI with a persistent identifier." The `DistributionShape` only mandates `schema:contentUrl` (HTTPS, reachable) – no PID constraint. Softened to "a reachable HTTPS URL."
- **Dataset metadata**: previously a `should` on the metadata URL. The actual durable-identifier requirement in NDE-DATASETS applies to the dataset IRI itself (`MUST maintain a permanent and unique identifier for each dataset`). Restated accordingly.
